### PR TITLE
Add manufacturing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,21 +115,24 @@ Evaluation isn't just a final checkpoint—it's a continuous feedback mechanism 
 
 ## 🎯 Supported Scenarios
 
-### 🐟 Fish Species Classification
-**Problem**: Multi-stage ML pipeline processing echogram images from underwater devices for real-time fish species identification in commercial fishing operations.
+The framework supports multiple industrial scenarios with ready-to-use configurations. Here are three representative scenarios covering different evaluation challenges:
+
+### ✈️ Aircraft Landing
+**Problem**: Advanced aircraft landing system with comprehensive safety and compliance requirements.
 
 **Challenges**:
-- **📊 Data Quality**: Echogram images from underwater devices vary in clarity, depth, and environmental conditions
-- **🔗 Pipeline Reliability**: Any stage failure breaks the entire classification process during active fishing operations
-- **💰 Business Impact**: Incorrect species identification affects catch management, regulatory compliance, and fishing efficiency
-- **⚡ Real-time Constraints**: Decisions must be made quickly during active fishing to optimize catch and avoid bycatch
+- **🛡️ Safety Requirements**: 99.999% accuracy for landing decisions with sub-500ms response time
+- **📋 Regulatory Compliance**: Must meet multiple aviation safety standards (DO-178C, DO-254, ARP4754A)
+- **⚡ Real-time Constraints**: Complex flight path optimization and obstacle detection
+- **🚨 Failure Consequences**: Incorrect decisions can lead to catastrophic outcomes
+- **🌊 Environmental Adaptation**: System must adapt to various weather and runway conditions
 
 **Framework Solution**:
-- **🔍 End-to-end monitoring**: Track performance across echogram preprocessing → feature extraction → species classification → catch optimization
-- **📊 Data quality validation**: Detect drift in echogram characteristics and underwater conditions
-- **🛡️ Reliability assessment**: Ensure 99.9% pipeline availability with automatic failover during fishing operations
-- **💰 Business metrics**: Connect technical performance to fishing efficiency and regulatory compliance
-- **🌊 Environmental adaptation**: Monitor water conditions and adjust model behavior for different fishing environments
+- **🛡️ Multi-faceted safety validation**: Flight path accuracy, runway identification, weather assessment, obstacle detection
+- **📋 Comprehensive regulatory compliance**: Automated validation against multiple aviation standards
+- **🚨 Real-time alerting**: Immediate notification of any performance degradation across all critical metrics
+- **🚨 Incident response**: Structured approach to handling safety-critical failures with multiple stakeholders
+- **🌊 Environmental monitoring**: Continuous adaptation to changing flight conditions
 
 ### 🚢 Maritime Collision Avoidance
 **Problem**: AI-powered collision avoidance system for commercial vessels operating in busy maritime environments with strict safety and regulatory requirements.
@@ -148,22 +151,28 @@ Evaluation isn't just a final checkpoint—it's a continuous feedback mechanism 
 - **🌊 Environmental adaptation**: System performance monitoring under various weather and sea conditions
 - **📊 Navigation parameter validation**: Continuous monitoring of Speed Through Water (STW) vs Speed Over Ground (SOG) discrepancies
 
-### ✈️ Aircraft Landing
-**Problem**: Advanced aircraft landing system with comprehensive safety and compliance requirements.
+### 🔧 Predictive Maintenance
+**Problem**: Industrial equipment predictive maintenance system for manufacturing operations with business-critical reliability requirements.
 
 **Challenges**:
-- **🛡️ Safety Requirements**: 99.999% accuracy for landing decisions with sub-500ms response time
-- **📋 Regulatory Compliance**: Must meet multiple aviation safety standards (DO-178C, DO-254, ARP4754A)
-- **⚡ Real-time Constraints**: Complex flight path optimization and obstacle detection
-- **🚨 Failure Consequences**: Incorrect decisions can lead to catastrophic outcomes
-- **🌊 Environmental Adaptation**: System must adapt to various weather and runway conditions
+- **💰 Business Impact**: Equipment failures cause immediate production losses and safety risks
+- **⚡ Real-time Monitoring**: Continuous assessment of equipment health across multiple production lines
+- **📊 Data Quality**: Sensor data from harsh industrial environments varies in reliability and accuracy
+- **🛡️ Safety Requirements**: Equipment failures can create hazardous conditions for workers
+- **📋 Regulatory Compliance**: Must meet manufacturing safety standards and environmental regulations
 
 **Framework Solution**:
-- **🛡️ Multi-faceted safety validation**: Flight path accuracy, runway identification, weather assessment, obstacle detection
-- **📋 Comprehensive regulatory compliance**: Automated validation against multiple aviation standards
-- **🚨 Real-time alerting**: Immediate notification of any performance degradation across all critical metrics
-- **🚨 Incident response**: Structured approach to handling safety-critical failures with multiple stakeholders
-- **🌊 Environmental monitoring**: Continuous adaptation to changing flight conditions
+- **🔍 Multi-equipment monitoring**: Track performance across different equipment types and production environments
+- **📊 Sensor data validation**: Detect drift in sensor characteristics and environmental conditions
+- **🛡️ Reliability assessment**: Ensure 99.5% prediction accuracy with automatic alerting for maintenance needs
+- **💰 Business metrics**: Connect technical performance to production efficiency and cost optimization
+- **🌊 Environmental adaptation**: Monitor operating conditions and adjust predictions for different equipment states
+
+### 📋 Additional Scenarios
+
+See the [`examples/`](./examples/) directory for complete configuration files covering additional scenarios:
+- **[🐟 fish-species-classification.yaml](./examples/fish-species-classification.yaml)**: Multi-stage workflow for underwater fish species classification
+- **[📊 product-demand-forecasting.yaml](./examples/product-demand-forecasting.yaml)**: Supply chain optimization and demand forecasting
 
 ## 🏗️ Architecture
 
@@ -267,24 +276,14 @@ ml-eval template --industry energy --type grid_optimization --output grid-system
 
 # Using example configurations
 ml-eval dev --config examples/aircraft-landing.yaml --mode validation --strict
-ml-eval evaluate --config examples/fish-species-classification.yaml --mode single
-ml-eval monitor --config examples/maritime-collision-avoidance.yaml --interval 60
-ml-eval evaluate --config examples/predictive-maintenance.yaml --mode continuous
+ml-eval evaluate --config examples/maritime-collision-avoidance.yaml --mode single
+ml-eval monitor --config examples/predictive-maintenance.yaml --interval 60
 
 # Additional reporting
 ml-eval report --type safety --period 30d
 ```
 
 ### 📋 Configuration Examples
-
-#### **📁 Available Example Configurations**
-
-The framework includes several complete example configurations in the [`examples/`](./examples/) directory:
-
-- **[✈️ aircraft-landing.yaml](./examples/aircraft-landing.yaml)**: Comprehensive aircraft landing system with safety-critical compliance (DO-178C, DO-254, ARP4754A)
-- **[🐟 fish-species-classification.yaml](./examples/fish-species-classification.yaml)**: Multi-stage workflow for underwater fish species classification
-- **[🚢 maritime-collision-avoidance.yaml](./examples/maritime-collision-avoidance.yaml)**: Maritime safety system with COLREGs compliance
-- **[🔧 predictive-maintenance.yaml](./examples/predictive-maintenance.yaml)**: Industrial equipment predictive maintenance with failure prediction and cost optimization
 
 #### **📋 Using Industry Templates (Recommended)**
 
@@ -296,13 +295,17 @@ ml-eval template --industry manufacturing --type list
 ml-eval template --industry manufacturing --type predictive_maintenance > maintenance-system.yaml
 ```
 
-#### **🏭 Manufacturing Quality Control Example**
+#### **📁 Example Configurations**
 
-See [examples/fish-species-classification.yaml](./examples/fish-species-classification.yaml) for a complete workflow example with similar structure.
+The framework includes complete example configurations in the [`examples/`](./examples/) directory for the scenarios described above:
 
-#### **✈️ Aviation Safety System Example**
+- **[✈️ aircraft-landing.yaml](./examples/aircraft-landing.yaml)**: Aircraft landing system with safety-critical compliance
+- **[🚢 maritime-collision-avoidance.yaml](./examples/maritime-collision-avoidance.yaml)**: Maritime safety system with COLREGs compliance  
+- **[🔧 predictive-maintenance.yaml](./examples/predictive-maintenance.yaml)**: Industrial equipment predictive maintenance
 
-See [examples/aircraft-landing.yaml](./examples/aircraft-landing.yaml) for a comprehensive aircraft landing system with multiple evaluators, collectors, and safety thresholds.
+Additional examples include:
+- **[🐟 fish-species-classification.yaml](./examples/fish-species-classification.yaml)**: Multi-stage workflow for underwater classification
+- **[📊 product-demand-forecasting.yaml](./examples/product-demand-forecasting.yaml)**: Supply chain optimization and demand forecasting
 
 ## 🔧 Core Components
 
@@ -350,7 +353,6 @@ This framework enables a new approach to Industrial AI development where safety 
 
 ```python
 # Define safety-critical SLOs before model development
-# See docs/reference/slo-configuration.md for comprehensive SLO configuration examples
 slos = {
     "false_positive_rate": SLOConfig(target=0.0001, error_budget=0.0001, compliance="DO-178C"),
     "response_time": SLOConfig(target=50, error_budget=0.001, safety_critical=True),
@@ -379,7 +381,6 @@ while training:
 from ml_eval import EvaluationFramework
 
 # Create framework for workflow evaluation
-# See docs/reference/slo-configuration.md for SLO configuration examples
 config = {
     "system": {
         "name": "Workflow System",

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ For detailed installation instructions, see [docs/user-guides/installation.md](.
 ml-eval template --industry manufacturing --type list
 
 # 2. Get a specific template for your industry
-ml-eval template --industry manufacturing --type quality_control > quality-system.yaml
+ml-eval template --industry manufacturing --type predictive_maintenance > maintenance-system.yaml
 
 # 3. Customize your configuration
 # Edit the generated .yaml file with your specific requirements
@@ -240,8 +240,8 @@ ml-eval report --type reliability --period 30d
 The framework provides ready-to-use templates for these industrial sectors:
 
 #### **🏭 Manufacturing Industry**
-- **🔍 quality_control**: Quality control system for defect detection and inspection
-- **🔧 predictive_maintenance**: Predictive maintenance system for equipment monitoring
+- **🔧 predictive_maintenance**: Predictive maintenance system for equipment monitoring and failure prediction
+- **📊 demand_forecasting**: Demand forecasting system for supply chain optimization
 
 #### **✈️ Aviation Industry**  
 - **🛡️ safety_decision**: Safety-critical decision system for aviation safety
@@ -269,6 +269,7 @@ ml-eval template --industry energy --type grid_optimization --output grid-system
 ml-eval dev --config examples/aircraft-landing.yaml --mode validation --strict
 ml-eval evaluate --config examples/fish-species-classification.yaml --mode single
 ml-eval monitor --config examples/maritime-collision-avoidance.yaml --interval 60
+ml-eval evaluate --config examples/predictive-maintenance.yaml --mode continuous
 
 # Additional reporting
 ml-eval report --type safety --period 30d
@@ -283,6 +284,7 @@ The framework includes several complete example configurations in the [`examples
 - **[✈️ aircraft-landing.yaml](./examples/aircraft-landing.yaml)**: Comprehensive aircraft landing system with safety-critical compliance (DO-178C, DO-254, ARP4754A)
 - **[🐟 fish-species-classification.yaml](./examples/fish-species-classification.yaml)**: Multi-stage workflow for underwater fish species classification
 - **[🚢 maritime-collision-avoidance.yaml](./examples/maritime-collision-avoidance.yaml)**: Maritime safety system with COLREGs compliance
+- **[🔧 predictive-maintenance.yaml](./examples/predictive-maintenance.yaml)**: Industrial equipment predictive maintenance with failure prediction and cost optimization
 
 #### **📋 Using Industry Templates (Recommended)**
 
@@ -291,7 +293,7 @@ The framework includes several complete example configurations in the [`examples
 ml-eval template --industry manufacturing --type list
 
 # Get a specific template
-ml-eval template --industry manufacturing --type quality_control > quality-control.yaml
+ml-eval template --industry manufacturing --type predictive_maintenance > maintenance-system.yaml
 ```
 
 #### **🏭 Manufacturing Quality Control Example**

--- a/docs/developer/api-reference.md
+++ b/docs/developer/api-reference.md
@@ -114,10 +114,10 @@ GET /templates
 {
   "templates": [
     {
-      "id": "manufacturing-basic",
-      "name": "Basic Manufacturing",
+      "id": "manufacturing-predictive_maintenance",
+      "name": "Manufacturing Predictive Maintenance",
       "industry": "manufacturing",
-      "description": "Basic manufacturing quality control template",
+      "description": "Manufacturing predictive maintenance template",
       "version": "1.0.0"
     }
   ],
@@ -492,7 +492,7 @@ validation = client.validate_configuration("config_123")
 templates = client.list_templates(industry="manufacturing")
 
 # Use template
-config = client.use_template("manufacturing-basic", {
+config = client.use_template("manufacturing-predictive_maintenance", {
     "system.name": "My System",
     "data_sources.0.connection": "postgresql://user:pass@localhost/db"
 })

--- a/docs/user-guides/cli-reference.md
+++ b/docs/user-guides/cli-reference.md
@@ -202,8 +202,8 @@ ml-eval config template [OPTIONS] TYPE
 
 **Examples:**
 ```bash
-# Generate basic template
-ml-eval config template basic --output my_config.yaml
+# Generate predictive maintenance template
+ml-eval config template predictive_maintenance --output my_config.yaml
 
 # Generate industry-specific template
 ml-eval config template manufacturing --output manufacturing_config.yaml
@@ -260,7 +260,7 @@ ml-eval templates use [OPTIONS] TEMPLATE
 **Examples:**
 ```bash
 # Use manufacturing template
-ml-eval templates use manufacturing-basic --output config.yaml
+ml-eval templates use manufacturing-predictive_maintenance --output config.yaml
 
 # Use with customization
 ml-eval templates use aviation-safety --customize
@@ -288,7 +288,7 @@ ml-eval templates customize [OPTIONS] TEMPLATE
 **Examples:**
 ```bash
 # Customize template
-ml-eval templates customize manufacturing-basic --output my_config.yaml
+ml-eval templates customize manufacturing-predictive_maintenance --output my_config.yaml
 
 # Interactive customization
 ml-eval templates customize aviation-safety --interactive
@@ -319,7 +319,7 @@ ml-eval templates create [OPTIONS] NAME
 ml-eval templates create my-industry --output my_template.yaml
 
 # Create based on existing template
-ml-eval templates create my-manufacturing --base manufacturing-basic
+ml-eval templates create my-manufacturing --base manufacturing-predictive_maintenance
 
 # Create with description
 ml-eval templates create my-aviation --industry aviation --description "Custom aviation template"
@@ -343,7 +343,7 @@ ml-eval templates edit [OPTIONS] TEMPLATE
 **Examples:**
 ```bash
 # Edit template
-ml-eval templates edit manufacturing-basic
+ml-eval templates edit manufacturing-predictive_maintenance
 
 # Edit with specific editor
 ml-eval templates edit aviation-safety --editor vim
@@ -370,7 +370,7 @@ ml-eval templates validate [OPTIONS] TEMPLATE
 **Examples:**
 ```bash
 # Validate template
-ml-eval templates validate manufacturing-basic
+ml-eval templates validate manufacturing-predictive_maintenance
 
 # Strict validation
 ml-eval templates validate aviation-safety --strict
@@ -398,7 +398,7 @@ ml-eval templates test [OPTIONS] TEMPLATE
 **Examples:**
 ```bash
 # Test with sample data
-ml-eval templates test manufacturing-basic --sample-data
+ml-eval templates test manufacturing-predictive_maintenance --sample-data
 
 # Test with specific data
 ml-eval templates test aviation-safety --data-file test_data.csv
@@ -686,7 +686,7 @@ The CLI uses the following exit codes:
 
 ```bash
 # 1. Create configuration from template
-ml-eval templates use manufacturing-basic --output config.yaml
+ml-eval templates use manufacturing-predictive_maintenance --output config.yaml
 
 # 2. Customize configuration
 ml-eval config template manufacturing --customize

--- a/docs/user-guides/first-evaluation.md
+++ b/docs/user-guides/first-evaluation.md
@@ -17,7 +17,7 @@ Start with a template that matches your industry:
 ml-eval templates list
 
 # Use a template for your industry
-ml-eval templates use manufacturing-basic
+ml-eval templates use manufacturing-predictive_maintenance
 ```
 
 ## 📊 Step 2: Configure Your Data Sources

--- a/docs/user-guides/getting-started.md
+++ b/docs/user-guides/getting-started.md
@@ -35,14 +35,14 @@ ml-eval --version
 
 ### 1️⃣ Choose a Template
 
-The framework provides industry-specific templates. For your first evaluation, we recommend starting with a basic template:
+The framework provides industry-specific templates. For your first evaluation, we recommend starting with a functional template:
 
 ```bash
 # List available templates
 ml-eval templates list
 
-# Use a basic template for manufacturing
-ml-eval templates use manufacturing-basic
+# Use a predictive maintenance template for manufacturing
+ml-eval templates use manufacturing-predictive_maintenance
 ```
 
 ### 2️⃣ Configure Your System

--- a/docs/user-guides/templates.md
+++ b/docs/user-guides/templates.md
@@ -6,63 +6,63 @@ This directory contains pre-configured templates for different industries, desig
 
 ### 🏭 Manufacturing Templates
 
-#### 🔍 Basic Manufacturing Quality Control
-**📄 File**: `manufacturing-basic.yaml`
-**🎯 Use Case**: General quality control systems
-**📊 Key Metrics**: Accuracy, precision, recall, defect rate
+#### 🔧 Manufacturing Predictive Maintenance
+**📄 File**: `manufacturing-predictive_maintenance.yaml`
+**🎯 Use Case**: Equipment monitoring and predictive maintenance systems
+**📊 Key Metrics**: Failure prediction accuracy, maintenance cost reduction, downtime reduction
 
 ```yaml
 system:
-  name: "Manufacturing Quality Control"
+  name: "Manufacturing Predictive Maintenance"
   criticality: "business-critical"
 
 data_sources:
-  - name: "quality_data"
+  - name: "equipment_data"
     type: "database"
-    connection: "postgresql://user:pass@localhost/quality_db"
-    tables: ["quality_measurements", "defect_reports"]
+    connection: "postgresql://user:pass@localhost/equipment_db"
+    tables: ["sensor_readings", "maintenance_history", "failure_events"]
 
 collectors:
-  - name: "quality_metrics"
+  - name: "equipment_metrics"
     type: "offline"
-    data_source: "quality_data"
-    metrics: ["accuracy", "precision", "recall", "f1_score"]
+    data_source: "equipment_data"
+    metrics: ["vibration", "temperature", "pressure", "current", "voltage"]
 
 evaluators:
-  - name: "quality_performance"
+  - name: "maintenance_performance"
     type: "performance"
     thresholds:
-      accuracy: 0.95
-      precision: 0.90
-      recall: 0.85
+      failure_prediction_accuracy: 0.92
+      maintenance_cost_reduction: 0.15
+      downtime_reduction: 0.20
 
-  - name: "quality_drift"
+  - name: "equipment_drift"
     type: "drift"
     detection_method: "statistical"
     sensitivity: 0.05
 
 reports:
-  - name: "quality_report"
+  - name: "maintenance_report"
     type: "business"
     format: "html"
     output_path: "./reports/"
 
 slo:
   availability: 0.999
-  accuracy: 0.95
-  latency_p95: 100
+  failure_prediction_accuracy: 0.92
+  maintenance_cost_reduction: 0.15
 ```
 
-#### 🔧 Advanced Manufacturing with Predictive Maintenance
-**📄 File**: `manufacturing-advanced.yaml`
-**🎯 Use Case**: Predictive maintenance and quality control
-**📊 Key Metrics**: Equipment health, failure prediction, maintenance costs
+#### 📊 Manufacturing Demand Forecasting
+**📄 File**: `manufacturing-demand_forecasting.yaml`
+**🎯 Use Case**: Demand forecasting and supply chain optimization
+**📊 Key Metrics**: Forecast accuracy, inventory optimization, supply chain efficiency
 
 ### ✈️ Aviation Templates
 
-#### 🛡️ Safety-Critical Flight Systems
-**📄 File**: `aviation-safety.yaml`
-**🎯 Use Case**: Flight control and safety systems
+#### 🛡️ Aviation Safety Decision System
+**📄 File**: `aviation-safety_decision.yaml`
+**🎯 Use Case**: Safety-critical decision systems for aviation operations
 **📊 Key Metrics**: Safety margins, failure probability, response time
 
 ```yaml
@@ -106,16 +106,16 @@ slo:
   response_time_p99: 50
 ```
 
-#### 🔧 Aircraft Maintenance Prediction
-**📄 File**: `aviation-maintenance.yaml`
-**🎯 Use Case**: Predictive maintenance for aircraft components
-**📊 Key Metrics**: Component health, maintenance scheduling, cost optimization
+#### ✈️ Aviation Flight Control System
+**📄 File**: `aviation-flight_control.yaml`
+**🎯 Use Case**: Advanced flight control and navigation systems
+**📊 Key Metrics**: Flight path accuracy, weather assessment, obstacle detection
 
 ### ⚡ Energy Templates
 
-#### ⚡ Grid Optimization Systems
-**📄 File**: `energy-grid.yaml`
-**🎯 Use Case**: Power grid optimization and demand prediction
+#### ⚡ Energy Grid Optimization
+**📄 File**: `energy-grid_optimization.yaml`
+**🎯 Use Case**: Power grid optimization and load balancing
 **📊 Key Metrics**: Grid stability, demand accuracy, efficiency
 
 ```yaml
@@ -159,15 +159,15 @@ slo:
   grid_stability: 0.99
 ```
 
-#### 🌞 Renewable Energy Forecasting
-**📄 File**: `energy-renewable.yaml`
-**🎯 Use Case**: Solar and wind power forecasting
+#### 📊 Energy Demand Prediction
+**📄 File**: `energy-demand_prediction.yaml`
+**🎯 Use Case**: Energy demand forecasting and capacity planning
 **📊 Key Metrics**: Forecast accuracy, energy production, cost optimization
 
 ### 🚢 Maritime Templates
 
 #### 🚢 Maritime Collision Avoidance
-**📄 File**: `maritime-collision-avoidance.yaml`
+**📄 File**: `maritime-collision_avoidance.yaml`
 **🎯 Use Case**: Ship collision avoidance and navigational safety
 **📊 Key Metrics**: Collision avoidance accuracy, alert latency, false alarm rate, STW/SOG discrepancy, system availability
 
@@ -234,6 +234,58 @@ evaluators:
     real_time_threshold: 2000  # ms
 ```
 
+## 📋 Configuration Examples
+
+#### **📁 Available Example Configurations**
+
+The framework includes several complete example configurations in the [`examples/`](./examples/) directory:
+
+- **[✈️ aircraft-landing.yaml](./examples/aircraft-landing.yaml)**: Comprehensive aircraft landing system with safety-critical compliance (DO-178C, DO-254, ARP4754A)
+- **[🐟 fish-species-classification.yaml](./examples/fish-species-classification.yaml)**: Multi-stage workflow for underwater fish species classification
+- **[🚢 maritime-collision-avoidance.yaml](./examples/maritime-collision-avoidance.yaml)**: Maritime safety system with COLREGs compliance
+- **[🔧 predictive-maintenance.yaml](./examples/predictive-maintenance.yaml)**: Industrial equipment predictive maintenance with failure prediction and cost optimization
+
+#### **📋 Using Industry Templates (Recommended)**
+
+```bash
+# List available templates
+ml-eval templates list
+
+# Use a specific template
+ml-eval templates use manufacturing-predictive_maintenance
+
+# Customize the template
+ml-eval templates customize manufacturing-predictive_maintenance --output my-config.yaml
+```
+
+#### **🏭 Manufacturing Predictive Maintenance Example**
+
+See [examples/fish-species-classification.yaml](./examples/fish-species-classification.yaml) for a complete workflow example with similar structure.
+
+#### **✈️ Aviation Safety System Example**
+
+See [examples/aircraft-landing.yaml](./examples/aircraft-landing.yaml) for a comprehensive aircraft landing system with multiple evaluators, collectors, and safety thresholds.
+
+#### **🔧 Predictive Maintenance Example**
+
+See [examples/predictive-maintenance.yaml](./examples/predictive-maintenance.yaml) for a comprehensive predictive maintenance system with:
+
+- **Equipment Monitoring**: Vibration, temperature, pressure, current, voltage sensors
+- **Failure Prediction**: Random Forest classification for failure prediction within 48 hours
+- **Remaining Life Estimation**: Gradient Boosting regression for days-to-failure prediction
+- **Cost Optimization**: Maintenance cost reduction and downtime minimization
+- **Regulatory Compliance**: ISO-10816, ISO-7919, API-670 standards
+- **Business Metrics**: Maintenance cost reduction, equipment lifetime optimization
+- **Alert System**: Critical failure alerts, maintenance scheduling, performance degradation warnings
+
+**Key Features:**
+- Real-time equipment monitoring with multiple sensor types
+- Dual ML models for classification and regression tasks
+- Comprehensive SLOs for prediction accuracy and business impact
+- Regulatory compliance for industrial equipment standards
+- Automated alerting and maintenance scheduling
+- Cost optimization and downtime reduction tracking
+
 ## Using Templates
 
 ### 1. List Available Templates
@@ -246,17 +298,17 @@ ml-eval templates list
 
 ```bash
 # Use a specific template
-ml-eval templates use manufacturing-basic
+ml-eval templates use manufacturing-predictive_maintenance
 
 # Customize the template
-ml-eval templates customize manufacturing-basic --output my-config.yaml
+ml-eval templates customize manufacturing-predictive_maintenance --output my-config.yaml
 ```
 
 ### 3. Create Custom Template
 
 ```bash
 # Create a new template based on existing one
-ml-eval templates create my-industry --base manufacturing-basic
+ml-eval templates create my-industry --base manufacturing-predictive_maintenance
 
 # Edit the template
 ml-eval templates edit my-industry
@@ -337,9 +389,9 @@ collectors:
 ## Industry-Specific Considerations
 
 ### Manufacturing
-- Focus on quality control metrics
-- Include defect detection rates
-- Monitor production efficiency
+- Focus on predictive maintenance metrics
+- Include equipment failure prediction
+- Monitor maintenance efficiency
 - Track cost implications
 
 ### Aviation
@@ -366,10 +418,10 @@ collectors:
 
 ```bash
 # Validate a template
-ml-eval templates validate manufacturing-basic
+ml-eval templates validate manufacturing-predictive_maintenance
 
 # Test a template with sample data
-ml-eval templates test manufacturing-basic --sample-data
+ml-eval templates test manufacturing-predictive_maintenance --sample-data
 ```
 
 ## Contributing Templates

--- a/examples/predictive-maintenance.yaml
+++ b/examples/predictive-maintenance.yaml
@@ -1,0 +1,188 @@
+system:
+  name: "Industrial Equipment Predictive Maintenance"
+  persona: "Maintenance Engineer"
+  criticality: "business_critical"
+  description: "ML system for predicting equipment failures and optimizing maintenance schedules"
+
+slos:
+  failure_prediction_accuracy:
+    target: 0.92
+    window: "30d"
+    description: "Accuracy of equipment failure prediction within 24-48 hours"
+  false_positive_rate:
+    target: 0.08
+    window: "30d"
+    description: "Rate of false positive failure predictions"
+  maintenance_cost_reduction:
+    target: 0.20
+    window: "90d"
+    description: "Reduction in maintenance costs through predictive maintenance"
+  system_availability:
+    target: 0.999
+    window: "30d"
+    description: "System uptime for predictive maintenance functionality"
+  prediction_response_time:
+    target: 0.99
+    window: "1h"
+    description: "Proportion of failure predictions completed within 5 minutes"
+
+safety_thresholds:
+  critical_equipment_alert:
+    max: 0.05
+    description: "Maximum acceptable false negative rate for critical equipment failure predictions"
+  maintenance_window:
+    min: 4
+    description: "Minimum hours advance warning required for critical equipment maintenance"
+
+operating_conditions:
+  equipment_types: ["pump", "motor", "compressor", "conveyor", "valve"]
+  operating_modes: ["normal", "high_load", "maintenance", "shutdown"]
+  environmental_conditions: ["normal", "high_temp", "high_humidity", "dusty"]
+
+collectors:
+  - type: "online"
+    endpoints: ["http://equipment-monitor:8080/metrics"]
+    metrics: ["vibration", "temperature", "pressure", "current", "voltage"]
+  - type: "offline"
+    log_paths: ["/var/log/equipment-sensors/", "/var/log/maintenance-records/"]
+  - type: "environmental"
+    sources: ["temperature_sensors", "humidity_sensors", "vibration_sensors"]
+  - type: "regulatory"
+    standards: ["ISO-10816", "ISO-7919", "API-670"]
+    compliance_metrics: ["vibration_limits", "temperature_limits"]
+
+evaluators:
+  - type: "performance"
+    metrics: ["failure_prediction_accuracy", "false_positive_rate"]
+    real_time_threshold: 300  # seconds
+  - type: "drift"
+    detection_methods: ["statistical", "ml_model"]
+    drift_metrics: ["vibration_patterns", "temperature_trends", "pressure_variations"]
+  - type: "reliability"
+    error_budget_window: "30d"
+    critical_metrics: ["system_availability", "prediction_response_time"]
+  - type: "business"
+    metrics: ["maintenance_cost_reduction", "downtime_reduction", "equipment_lifetime"]
+  - type: "compliance"
+    standards: ["ISO-10816", "ISO-7919"]
+    compliance_metrics: ["vibration_compliance", "temperature_compliance"]
+
+reports:
+  - type: "business"
+    frequency: "weekly"
+    stakeholders: ["maintenance_manager", "operations_manager", "plant_engineer"]
+  - type: "reliability"
+    frequency: "daily"
+    stakeholders: ["maintenance_crew", "equipment_technician"]
+  - type: "compliance"
+    frequency: "monthly"
+    stakeholders: ["safety_officer", "regulatory_authority"]
+
+data_sources:
+  - name: "equipment_sensors"
+    type: "database"
+    connection: "postgresql://user:pass@localhost/equipment_db"
+    tables: ["sensor_readings", "equipment_status", "maintenance_history"]
+  - name: "maintenance_records"
+    type: "database"
+    connection: "postgresql://user:pass@localhost/maintenance_db"
+    tables: ["maintenance_schedule", "failure_events", "cost_records"]
+  - name: "environmental_data"
+    type: "api"
+    endpoint: "http://environmental-monitor:8080/api/v1/readings"
+    authentication: "api_key"
+  - name: "equipment_specs"
+    type: "file"
+    path: "/data/equipment_specifications.json"
+    format: "json"
+
+features:
+  - name: "vibration_rms"
+    description: "Root mean square vibration amplitude"
+    unit: "mm/s"
+    range: [0, 50]
+  - name: "temperature"
+    description: "Equipment operating temperature"
+    unit: "°C"
+    range: [0, 150]
+  - name: "pressure"
+    description: "Operating pressure"
+    unit: "bar"
+    range: [0, 100]
+  - name: "current"
+    description: "Motor current consumption"
+    unit: "A"
+    range: [0, 500]
+  - name: "voltage"
+    description: "Operating voltage"
+    unit: "V"
+    range: [0, 1000]
+  - name: "runtime_hours"
+    description: "Equipment runtime since last maintenance"
+    unit: "hours"
+    range: [0, 8760]
+  - name: "load_factor"
+    description: "Equipment load factor percentage"
+    unit: "%"
+    range: [0, 100]
+
+models:
+  - name: "failure_prediction"
+    type: "classification"
+    algorithm: "random_forest"
+    target: "failure_within_48h"
+    features: ["vibration_rms", "temperature", "pressure", "current", "runtime_hours", "load_factor"]
+    hyperparameters:
+      n_estimators: 100
+      max_depth: 10
+      min_samples_split: 5
+  - name: "remaining_life"
+    type: "regression"
+    algorithm: "gradient_boosting"
+    target: "days_to_failure"
+    features: ["vibration_rms", "temperature", "pressure", "current", "runtime_hours", "load_factor"]
+    hyperparameters:
+      n_estimators: 200
+      learning_rate: 0.1
+      max_depth: 6
+
+training:
+  data_freshness:
+    max_age: "7d"
+    description: "Maximum age of training data before retraining"
+  retraining_trigger:
+    performance_degradation: 0.05
+    data_drift_threshold: 0.1
+    time_interval: "30d"
+  validation:
+    test_size: 0.2
+    cross_validation_folds: 5
+    metrics: ["accuracy", "precision", "recall", "f1_score", "mae"]
+
+alerts:
+  - name: "critical_failure_predicted"
+    condition: "failure_probability > 0.8"
+    severity: "critical"
+    notification: ["maintenance_manager", "plant_engineer"]
+    action: "schedule_immediate_maintenance"
+  - name: "maintenance_due"
+    condition: "days_to_failure < 7"
+    severity: "warning"
+    notification: ["maintenance_crew"]
+    action: "schedule_maintenance_window"
+  - name: "performance_degradation"
+    condition: "prediction_accuracy < 0.85"
+    severity: "warning"
+    notification: ["ml_engineer"]
+    action: "retrain_model"
+
+monitoring:
+  dashboard:
+    url: "http://maintenance-dashboard:8080"
+    refresh_interval: 300
+  metrics_export:
+    format: "prometheus"
+    endpoint: "http://metrics-exporter:9090"
+  log_aggregation:
+    system: "elasticsearch"
+    index: "predictive-maintenance-logs" 

--- a/examples/predictive-maintenance.yaml
+++ b/examples/predictive-maintenance.yaml
@@ -5,18 +5,30 @@ system:
   description: "ML system for predicting equipment failures and optimizing maintenance schedules"
 
 slos:
-  failure_prediction_accuracy:
+  vae_anomaly_detection_accuracy:
+    target: 0.90
+    window: "30d"
+    description: "Accuracy of VAE-based anomaly detection for equipment failures"
+  rule_based_fault_detection_accuracy:
+    target: 0.85
+    window: "30d"
+    description: "Accuracy of rule-based fault prediction system"
+  ensemble_prediction_accuracy:
     target: 0.92
     window: "30d"
-    description: "Accuracy of equipment failure prediction within 24-48 hours"
+    description: "Combined accuracy of VAE and rule-based predictions"
   false_positive_rate:
     target: 0.08
     window: "30d"
-    description: "Rate of false positive failure predictions"
+    description: "Rate of false positive failure predictions across both models"
   maintenance_cost_reduction:
     target: 0.20
     window: "90d"
     description: "Reduction in maintenance costs through predictive maintenance"
+  downtime_reduction:
+    target: 0.30
+    window: "90d"
+    description: "Reduction in equipment downtime through predictive maintenance"
   system_availability:
     target: 0.999
     window: "30d"
@@ -41,19 +53,36 @@ operating_conditions:
 
 collectors:
   - type: "online"
-    endpoints: ["http://equipment-monitor:8080/metrics"]
+    source: "s3"
+    bucket: "equipment-maintenance-data"
+    prefix: "inference/"
     metrics: ["vibration", "temperature", "pressure", "current", "voltage"]
+    polling_interval: 60  # seconds
+    format: "json"
   - type: "offline"
-    log_paths: ["/var/log/equipment-sensors/", "/var/log/maintenance-records/"]
+    source: "s3"
+    bucket: "equipment-maintenance-data"
+    prefix: "training/"
+    data_types: ["sensor_readings", "equipment_status", "maintenance_history", "failure_events"]
+    format: "parquet"
+    batch_size: 10000
   - type: "environmental"
+    source: "s3"
+    bucket: "equipment-maintenance-data"
+    prefix: "environmental/"
     sources: ["temperature_sensors", "humidity_sensors", "vibration_sensors"]
+    format: "json"
   - type: "regulatory"
+    source: "s3"
+    bucket: "equipment-maintenance-data"
+    prefix: "compliance/"
     standards: ["ISO-10816", "ISO-7919", "API-670"]
     compliance_metrics: ["vibration_limits", "temperature_limits"]
+    format: "json"
 
 evaluators:
   - type: "performance"
-    metrics: ["failure_prediction_accuracy", "false_positive_rate"]
+    metrics: ["vae_anomaly_detection_accuracy", "rule_based_fault_detection_accuracy", "ensemble_prediction_accuracy", "false_positive_rate"]
     real_time_threshold: 300  # seconds
   - type: "drift"
     detection_methods: ["statistical", "ml_model"]
@@ -61,8 +90,12 @@ evaluators:
   - type: "reliability"
     error_budget_window: "30d"
     critical_metrics: ["system_availability", "prediction_response_time"]
-  - type: "business"
+  - type: "performance"
     metrics: ["maintenance_cost_reduction", "downtime_reduction", "equipment_lifetime"]
+    thresholds:
+      maintenance_cost_reduction: 0.20
+      downtime_reduction: 0.30
+      equipment_lifetime: 8760  # hours (1 year)
   - type: "compliance"
     standards: ["ISO-10816", "ISO-7919"]
     compliance_metrics: ["vibration_compliance", "temperature_compliance"]
@@ -79,102 +112,110 @@ reports:
     stakeholders: ["safety_officer", "regulatory_authority"]
 
 data_sources:
-  - name: "equipment_sensors"
-    type: "database"
-    connection: "postgresql://user:pass@localhost/equipment_db"
-    tables: ["sensor_readings", "equipment_status", "maintenance_history"]
-  - name: "maintenance_records"
-    type: "database"
-    connection: "postgresql://user:pass@localhost/maintenance_db"
-    tables: ["maintenance_schedule", "failure_events", "cost_records"]
-  - name: "environmental_data"
-    type: "api"
-    endpoint: "http://environmental-monitor:8080/api/v1/readings"
-    authentication: "api_key"
-  - name: "equipment_specs"
-    type: "file"
-    path: "/data/equipment_specifications.json"
-    format: "json"
-
-features:
-  - name: "vibration_rms"
-    description: "Root mean square vibration amplitude"
-    unit: "mm/s"
-    range: [0, 50]
-  - name: "temperature"
-    description: "Equipment operating temperature"
-    unit: "°C"
-    range: [0, 150]
-  - name: "pressure"
-    description: "Operating pressure"
-    unit: "bar"
-    range: [0, 100]
-  - name: "current"
-    description: "Motor current consumption"
-    unit: "A"
-    range: [0, 500]
-  - name: "voltage"
-    description: "Operating voltage"
-    unit: "V"
-    range: [0, 1000]
-  - name: "runtime_hours"
-    description: "Equipment runtime since last maintenance"
-    unit: "hours"
-    range: [0, 8760]
-  - name: "load_factor"
-    description: "Equipment load factor percentage"
-    unit: "%"
-    range: [0, 100]
+  - name: "equipment_data"
+    type: "s3"
+    bucket: "equipment-maintenance-data"
+    region: "us-east-1"
+    authentication: "aws_iam"
+    offline_training:
+      prefix: "training/"
+      data_types: ["sensor_readings", "equipment_status", "maintenance_history", "failure_events"]
+      format: "parquet"
+      compression: "snappy"
+    online_inference:
+      prefix: "inference/"
+      data_types: ["real_time_sensors", "equipment_status"]
+      format: "json"
+      streaming: true
+    backup:
+      prefix: "backup/"
+      retention_days: 365
 
 models:
-  - name: "failure_prediction"
-    type: "classification"
-    algorithm: "random_forest"
-    target: "failure_within_48h"
-    features: ["vibration_rms", "temperature", "pressure", "current", "runtime_hours", "load_factor"]
+  - name: "vae_predictive_maintenance"
+    type: "anomaly_detection"
+    algorithm: "variational_autoencoder"
+    target: "equipment_anomaly_score"
+    features: ["vibration_rms", "temperature", "pressure", "current", "voltage", "runtime_hours", "load_factor"]
     hyperparameters:
-      n_estimators: 100
-      max_depth: 10
-      min_samples_split: 5
-  - name: "remaining_life"
-    type: "regression"
-    algorithm: "gradient_boosting"
-    target: "days_to_failure"
-    features: ["vibration_rms", "temperature", "pressure", "current", "runtime_hours", "load_factor"]
-    hyperparameters:
-      n_estimators: 200
-      learning_rate: 0.1
-      max_depth: 6
+      latent_dim: 32
+      hidden_dims: [128, 64, 32]
+      learning_rate: 0.001
+      batch_size: 64
+      epochs: 100
+    description: "Main VAE-based predictive maintenance model for anomaly detection"
+  - name: "rule_based_fault_prediction"
+    type: "rule_engine"
+    algorithm: "expert_rules"
+    target: "fault_probability"
+    features: ["vibration_rms", "temperature", "pressure", "current", "voltage"]
+    rules:
+      - condition: "vibration_rms > 25 AND temperature > 120"
+        fault_type: "bearing_wear"
+        probability: 0.85
+      - condition: "temperature > 140 OR current > 450"
+        fault_type: "overheating"
+        probability: 0.90
+      - condition: "pressure > 80 AND vibration_rms > 30"
+        fault_type: "pressure_system_fault"
+        probability: 0.75
+    description: "Rule-based fault prediction system for immediate fault detection"
 
 training:
-  data_freshness:
-    max_age: "7d"
-    description: "Maximum age of training data before retraining"
-  retraining_trigger:
-    performance_degradation: 0.05
-    data_drift_threshold: 0.1
-    time_interval: "30d"
-  validation:
-    test_size: 0.2
-    cross_validation_folds: 5
-    metrics: ["accuracy", "precision", "recall", "f1_score", "mae"]
+  workflow:
+    step1:
+      name: "vae_predictive_maintenance"
+      type: "unsupervised"
+      description: "VAE-based anomaly detection for predictive maintenance"
+      data_freshness:
+        max_age: "7d"
+        description: "Maximum age of training data before retraining"
+      retraining_trigger:
+        performance_degradation: 0.05
+        data_drift_threshold: 0.1
+        time_interval: "30d"
+      validation:
+        test_size: 0.2
+        metrics: ["reconstruction_error", "anomaly_detection_rate", "false_positive_rate"]
+    step2:
+      name: "rule_based_fault_prediction"
+      type: "rule_engine"
+      description: "Rule-based fault prediction for immediate fault detection"
+      rule_validation:
+        expert_review: "monthly"
+        rule_performance_tracking: true
+        metrics: ["rule_accuracy", "fault_detection_rate", "false_alarm_rate"]
+  model_ensemble:
+    combination_method: "weighted_average"
+    weights:
+      vae_predictive_maintenance: 0.7
+      rule_based_fault_prediction: 0.3
 
 alerts:
-  - name: "critical_failure_predicted"
-    condition: "failure_probability > 0.8"
+  - name: "vae_anomaly_detected"
+    condition: "vae_anomaly_score > 0.8"
     severity: "critical"
     notification: ["maintenance_manager", "plant_engineer"]
     action: "schedule_immediate_maintenance"
-  - name: "maintenance_due"
-    condition: "days_to_failure < 7"
-    severity: "warning"
-    notification: ["maintenance_crew"]
-    action: "schedule_maintenance_window"
-  - name: "performance_degradation"
-    condition: "prediction_accuracy < 0.85"
+    source: "vae_predictive_maintenance"
+  - name: "rule_based_fault_detected"
+    condition: "fault_probability > 0.75"
+    severity: "high"
+    notification: ["maintenance_crew", "equipment_technician"]
+    action: "investigate_equipment_condition"
+    source: "rule_based_fault_prediction"
+  - name: "ensemble_high_risk"
+    condition: "ensemble_score > 0.85"
+    severity: "critical"
+    notification: ["maintenance_manager", "plant_engineer", "maintenance_crew"]
+    action: "emergency_maintenance_protocol"
+    source: "model_ensemble"
+  - name: "vae_performance_degradation"
+    condition: "vae_reconstruction_error > 0.15"
     severity: "warning"
     notification: ["ml_engineer"]
-    action: "retrain_model"
+    action: "retrain_vae_model"
+    source: "vae_predictive_maintenance"
 
 monitoring:
   dashboard:
@@ -185,4 +226,4 @@ monitoring:
     endpoint: "http://metrics-exporter:9090"
   log_aggregation:
     system: "elasticsearch"
-    index: "predictive-maintenance-logs" 
+    index: "predictive-maintenance-logs"

--- a/examples/product-demand-forecasting.yaml
+++ b/examples/product-demand-forecasting.yaml
@@ -1,0 +1,204 @@
+system:
+  name: "Product Demand Forecasting System"
+  persona: "Supply Chain Manager"
+  criticality: "business_critical"
+  description: "Forecasting system for product demand to optimize equipment procurement"
+  training_mode: "online"
+  training_trigger: "real_time_data_availability"
+
+slos:
+  forecast_accuracy:
+    target: 0.85
+    window: "30d"
+    description: "Accuracy of demand forecasts"
+  
+  market_share_prediction:
+    target: 0.80
+    window: "30d"
+    description: "Accuracy of market share predictions"
+  
+  sales_volume_forecast:
+    target: 0.82
+    window: "30d"
+    description: "Accuracy of sales volume predictions"
+  
+  transaction_pattern_accuracy:
+    target: 0.88
+    window: "30d"
+    description: "Accuracy of transaction pattern recognition"
+  
+  competitor_analysis_accuracy:
+    target: 0.75
+    window: "30d"
+    description: "Accuracy of competitor behavior analysis"
+  
+  difficulty_assessment:
+    target: 0.78
+    window: "30d"
+    description: "Accuracy of supply chain difficulty assessment"
+  
+  model_training_latency:
+    target: 0.95
+    window: "24h"
+    description: "Proportion of model training completed within 2 hours of new data"
+  
+  training_data_freshness:
+    target: 0.99
+    window: "24h"
+    description: "Proportion of training using data from last 24 hours"
+
+collectors:
+  - type: "online"
+    endpoints: ["https://companyforecast.blob.core.windows.net/sales-analytics/metrics"]
+    metrics: ["forecast_accuracy", "market_share_prediction", "sales_volume_forecast", "model_training_latency", "training_data_freshness"]
+    polling_interval: 3600
+    real_time: true
+  
+  - type: "offline"
+    log_paths: ["https://companyforecast.blob.core.windows.net/logs/forecasting-system/"]
+    data_retention: "365d"
+    batch_size: 10000
+  
+  - type: "online"
+    endpoints: ["https://companyforecast.blob.core.windows.net/training-data/"]
+    metrics: ["training_data_volume", "data_quality_score", "feature_availability"]
+    polling_interval: 300
+    real_time: true
+
+evaluators:
+  - type: "reliability"
+    error_budget_window: "30d"
+    critical_metrics: ["forecast_accuracy", "market_share_prediction", "sales_volume_forecast", "model_training_latency"]
+    reliability_targets:
+      mttf: "720h"
+      mttr: "24h"
+      availability: 0.99
+    failure_modes: ["data_pipeline_failure", "model_degradation", "training_failure"]
+  
+  - type: "performance"
+    metrics: ["forecast_latency", "model_inference_time", "training_duration"]
+    real_time_threshold: 14400
+    performance_baselines:
+      normal_operation: 7200
+      degraded_operation: 14400
+      emergency_mode: 3600
+  
+  - type: "drift"
+    detection_methods: ["statistical", "ml_model"]
+    drift_metrics: ["market_share_prediction", "sales_volume_forecast", "training_data_freshness"]
+    drift_thresholds:
+      statistical: 0.15
+      ml_model: 0.20
+    environmental_factors: ["economic_conditions", "market_volatility"]
+
+reports:
+  - type: "business"
+    format: "html"
+    schedule: "0 8 * * 1"
+    recipients: ["supply_chain_manager@company.com"]
+    include_charts: true
+    include_recommendations: true
+
+# Forecasting model configurations
+forecasting_models:
+  market_share_model:
+    type: "ensemble"
+    algorithms: ["random_forest", "gradient_boosting", "neural_network"]
+    features: ["historical_market_share", "competitor_pricing", "marketing_spend", "unit_price"]
+    update_frequency: "online"
+    confidence_threshold: 0.80
+    training_config:
+      trigger: "new_sales_data"
+      batch_size: 1000
+      learning_rate: 0.01
+      retrain_threshold: 0.15
+  
+  sales_volume_model:
+    type: "time_series"
+    algorithms: ["arima", "prophet", "lstm"]
+    features: ["historical_sales", "seasonal_patterns", "promotional_events", "unit_price"]
+    update_frequency: "online"
+    forecast_horizon: "12_months"
+    training_config:
+      trigger: "new_transaction_data"
+      window_size: 30
+      retrain_threshold: 0.10
+  
+  transaction_pattern_model:
+    type: "clustering"
+    algorithms: ["k_means", "dbscan", "hierarchical"]
+    features: ["transaction_frequency", "purchase_amount", "product_categories", "unit_price"]
+    update_frequency: "online"
+    pattern_detection_threshold: 0.75
+    training_config:
+      trigger: "new_pos_data"
+      batch_size: 500
+      retrain_threshold: 0.20
+  
+  competitor_analysis_model:
+    type: "classification"
+    algorithms: ["support_vector_machine", "logistic_regression", "random_forest"]
+    features: ["competitor_pricing", "market_position", "product_launches", "unit_price"]
+    update_frequency: "online"
+    classification_threshold: 0.70
+    training_config:
+      trigger: "new_market_data"
+      batch_size: 200
+      retrain_threshold: 0.25
+  
+  difficulty_assessment_model:
+    type: "regression"
+    algorithms: ["linear_regression", "ridge_regression", "elastic_net"]
+    features: ["supply_chain_complexity", "lead_times", "supplier_reliability", "unit_price"]
+    update_frequency: "online"
+    risk_threshold: 0.60
+    training_config:
+      trigger: "new_inventory_data"
+      batch_size: 300
+      retrain_threshold: 0.18
+
+# Data sources and integration
+data_integration:
+  internal_sources:
+    - name: "sales_database"
+      type: "blob_storage"
+      connection: "https://companyforecast.blob.core.windows.net/sales-data/"
+      containers: ["sales_transactions", "product_catalog", "customer_data", "unit_prices"]
+      update_frequency: "hourly"
+    
+    - name: "pos_devices"
+      type: "blob_storage"
+      connection: "https://companyforecast.blob.core.windows.net/pos-data/"
+      containers: ["pos_transactions", "store_locations", "payment_methods", "real_time_sales"]
+      update_frequency: "real_time"
+    
+    - name: "inventory_system"
+      type: "blob_storage"
+      connection: "https://companyforecast.blob.core.windows.net/inventory-data/"
+      containers: ["inventory_levels", "supplier_data", "purchase_orders"]
+      update_frequency: "daily"
+    
+    - name: "market_research"
+      type: "blob_storage"
+      connection: "https://companyforecast.blob.core.windows.net/market-research/"
+      containers: ["market_share", "competitor_analysis", "industry_trends"]
+      update_frequency: "weekly"
+    
+    - name: "training_data"
+      type: "blob_storage"
+      connection: "https://companyforecast.blob.core.windows.net/training-data/"
+      containers: ["latest_sales", "latest_transactions", "model_features", "training_labels"]
+      update_frequency: "real_time"
+  
+  external_sources:
+    - name: "economic_indicators"
+      type: "blob_storage"
+      connection: "https://companyforecast.blob.core.windows.net/external-data/economic/"
+      containers: ["gdp_growth", "inflation_rate", "unemployment_rate"]
+      update_frequency: "monthly"
+    
+    - name: "social_media_sentiment"
+      type: "blob_storage"
+      connection: "https://companyforecast.blob.core.windows.net/external-data/sentiment/"
+      containers: ["brand_sentiment", "product_sentiment", "competitor_sentiment"]
+      update_frequency: "real_time"

--- a/ml_eval/core/types.py
+++ b/ml_eval/core/types.py
@@ -73,8 +73,8 @@ class TemplateType(Enum):
     """Template types per industry"""
 
     # Manufacturing
-    QUALITY_CONTROL = "quality_control"
     PREDICTIVE_MAINTENANCE = "predictive_maintenance"
+    DEMAND_FORECASTING = "demand_forecasting"
 
     # Aviation
     SAFETY_DECISION = "safety_decision"

--- a/ml_eval/templates/factory.py
+++ b/ml_eval/templates/factory.py
@@ -13,20 +13,20 @@ class TemplateFactory:
         """Load industry-specific templates"""
         return {
             "aviation": {
-                "basic": self._create_aviation_basic(),
-                "advanced": self._create_aviation_advanced(),
+                "safety_decision": self._create_aviation_safety_decision(),
+                "flight_control": self._create_aviation_flight_control(),
             },
             "energy": {
-                "basic": self._create_energy_basic(),
-                "advanced": self._create_energy_advanced(),
+                "grid_optimization": self._create_energy_grid_optimization(),
+                "demand_prediction": self._create_energy_demand_prediction(),
             },
             "manufacturing": {
-                "basic": self._create_manufacturing_basic(),
-                "advanced": self._create_manufacturing_advanced(),
+                "predictive_maintenance": self._create_manufacturing_predictive_maintenance(),
+                "demand_forecasting": self._create_manufacturing_demand_forecasting(),
             },
             "maritime": {
-                "basic": self._create_maritime_basic(),
-                "advanced": self._create_maritime_advanced(),
+                "collision_avoidance": self._create_maritime_collision_avoidance(),
+                "navigation_system": self._create_maritime_navigation_system(),
             },
         }
 
@@ -50,377 +50,320 @@ class TemplateFactory:
             return []
         return list(self.templates[industry].keys())
 
-    def _create_aviation_basic(self) -> dict[str, Any]:
-        """Create basic aviation template"""
+    def _create_aviation_safety_decision(self) -> dict[str, Any]:
+        """Create aviation safety decision template"""
         return {
             "system": {
-                "name": "Aircraft Landing System",
+                "name": "Aircraft Safety Decision System",
                 "persona": "Flight Crew",
                 "criticality": "safety_critical",
-                "description": "Advanced system for aircraft landing assistance and safety-critical landing decisions",
+                "description": "Safety-critical decision system for aircraft operations",
             },
             "slos": {
                 "flight_path_accuracy": {
                     "target": 0.9999,
                     "window": "24h",
-                    "description": "Accuracy of autonomous flight path predictions and trajectory optimization",
-                },
-                "runway_identification": {
-                    "target": 0.9995,
-                    "window": "24h",
-                    "description": "Accuracy of runway detection, classification, and approach path identification",
-                },
-                "landing_decision_confidence": {
-                    "target": 0.99999,
-                    "window": "24h",
-                    "description": "Confidence level in autonomous landing decisions and safety assessments",
+                    "description": "Accuracy of autonomous flight path predictions",
                 },
                 "system_response_time": {
                     "target": 0.99,
                     "window": "1h",
-                    "description": "Proportion of system responses within 500ms for critical flight decisions",
-                },
-            },
-            "safety_thresholds": {
-                "decision_confidence_threshold": {
-                    "min": 0.95,
-                    "description": "Minimum confidence threshold required for autonomous decisions",
-                },
-                "response_time_p99": {
-                    "max": 500,
-                    "description": "99th percentile response time for critical flight decisions",
+                    "description": "Proportion of system responses within 500ms",
                 },
             },
             "collectors": [
                 {
                     "type": "online",
                     "endpoints": ["http://flight-systems:8080/metrics"],
-                    "metrics": [
-                        "flight_path_accuracy",
-                        "runway_detection",
-                        "weather_assessment",
-                    ],
-                },
-                {
-                    "type": "environmental",
-                    "sources": ["weather_station", "radar", "gps", "altimeter"],
+                    "metrics": ["flight_path_accuracy", "response_time"],
                 },
             ],
             "evaluators": [
                 {
                     "type": "safety",
                     "compliance_standards": ["DO-178C"],
-                    "critical_metrics": [
-                        "landing_decision_confidence",
-                        "false_positive_rate",
-                    ],
-                },
-                {
-                    "type": "reliability",
-                    "error_budget_window": "30d",
-                    "critical_metrics": ["system_availability", "flight_path_accuracy"],
+                    "critical_metrics": ["flight_path_accuracy"],
                 },
             ],
         }
 
-    def _create_aviation_advanced(self) -> dict[str, Any]:
-        """Create advanced aviation template"""
-        basic = self._create_aviation_basic()
-        basic["system"]["name"] = "Advanced Aircraft Landing System"
-
-        # Add more comprehensive SLOs
-        basic["slos"].update(
-            {
-                "weather_condition_assessment": {
-                    "target": 0.995,
-                    "window": "24h",
-                    "description": "Accuracy of weather condition evaluation and impact assessment on landing",
-                },
-                "obstacle_detection": {
+    def _create_aviation_flight_control(self) -> dict[str, Any]:
+        """Create aviation flight control template"""
+        return {
+            "system": {
+                "name": "Advanced Aircraft Flight Control System",
+                "persona": "Flight Crew",
+                "criticality": "safety_critical",
+                "description": "Comprehensive flight control system with safety features",
+            },
+            "slos": {
+                "flight_path_accuracy": {
                     "target": 0.9999,
                     "window": "24h",
-                    "description": "Accuracy of obstacle detection and avoidance recommendations",
+                    "description": "Accuracy of autonomous flight path predictions",
                 },
-                "false_positive_rate": {
-                    "target": 0.001,
-                    "window": "7d",
-                    "description": "Rate of false positive alerts for safety-critical scenarios",
+                "system_response_time": {
+                    "target": 0.99,
+                    "window": "1h",
+                    "description": "Proportion of system responses within 500ms",
                 },
                 "system_availability": {
                     "target": 0.9999,
                     "window": "30d",
-                    "description": "System uptime for aircraft landing functionality",
+                    "description": "System uptime for flight control functionality",
                 },
-            }
-        )
-
-        # Add operating conditions
-        basic["operating_conditions"] = {
-            "flight_phases": ["approach", "final_approach", "landing", "rollout"],
-            "weather_conditions": [
-                "clear",
-                "fog",
-                "rain",
-                "crosswind",
-                "low_visibility",
+            },
+            "collectors": [
+                {
+                    "type": "online",
+                    "endpoints": ["http://flight-systems:8080/metrics"],
+                    "metrics": ["flight_path_accuracy", "response_time", "availability"],
+                },
             ],
-            "runway_types": [
-                "asphalt",
-                "concrete",
-                "grass",
-                "short_field",
-                "contaminated",
+            "evaluators": [
+                {
+                    "type": "safety",
+                    "compliance_standards": ["DO-178C"],
+                    "critical_metrics": ["flight_path_accuracy"],
+                },
+                {
+                    "type": "reliability",
+                    "error_budget_window": "30d",
+                    "critical_metrics": ["system_availability"],
+                },
             ],
         }
 
-        # Add more collectors
-        basic["collectors"].extend(
-            [
-                {
-                    "type": "offline",
-                    "log_paths": ["/var/log/flight-systems/", "/var/log/navigation/"],
-                },
-                {
-                    "type": "regulatory",
-                    "standards": ["FAA", "EASA", "ICAO"],
-                    "compliance_metrics": ["safety_margins", "operational_limits"],
-                },
-            ]
-        )
-
-        # Add more evaluators
-        basic["evaluators"].extend(
-            [
-                {
-                    "type": "performance",
-                    "metrics": ["system_response_time", "decision_confidence"],
-                    "real_time_threshold": 500,
-                },
-                {
-                    "type": "drift",
-                    "detection_methods": ["statistical", "ml_model"],
-                    "drift_metrics": [
-                        "flight_path_accuracy",
-                        "weather_assessment",
-                        "runway_identification",
-                    ],
-                },
-            ]
-        )
-
-        # Add reports
-        basic["reports"] = [
-            {
-                "type": "safety",
-                "frequency": "daily",
-                "stakeholders": [
-                    "flight_crew",
-                    "safety_officer",
-                    "regulatory_authority",
-                ],
-            },
-            {
-                "type": "reliability",
-                "frequency": "weekly",
-                "stakeholders": ["maintenance_crew", "operations_manager"],
-            },
-        ]
-
-        return basic
-
-    def _create_energy_basic(self) -> dict[str, Any]:
-        """Create basic energy template"""
+    def _create_energy_grid_optimization(self) -> dict[str, Any]:
+        """Create energy grid optimization template"""
         return {
             "system": {
-                "name": "Energy Grid ML System",
-                "type": "workflow",
-                "criticality": "safety_critical",
+                "name": "Energy Grid Optimization System",
+                "persona": "Grid Operator",
+                "criticality": "business_critical",
+                "description": "ML system for energy grid optimization and load balancing",
             },
             "slos": {
-                "grid_stability": {
-                    "target": 0.995,
-                    "window": "1h",
-                    "description": "Grid stability prediction accuracy",
-                    "safety_critical": True,
-                    "compliance_standard": "IEC-61508",
+                "load_prediction_accuracy": {
+                    "target": 0.95,
+                    "window": "24h",
+                    "description": "Accuracy of energy demand prediction",
                 },
                 "response_time": {
-                    "target": 50,
-                    "window": "5m",
-                    "description": "Emergency response time (ms)",
-                    "safety_critical": True,
-                },
-            },
-            "collectors": [
-                {
-                    "type": "online",
-                    "endpoint": "http://energy-grid:9090",
-                },
-                {
-                    "type": "environmental",
-                    "sensor_types": ["temperature", "pressure"],
-                },
-            ],
-            "evaluators": [
-                {
-                    "type": "safety",
-                    "compliance_standards": ["IEC-61508"],
-                },
-                {
-                    "type": "reliability",
-                    "error_budget_window": "30d",
-                    "slos": {
-                        "grid_stability": {
-                            "target": 0.995,
-                            "window": "1h",
-                            "description": "Grid stability prediction accuracy",
-                        },
-                        "emergency_response": {
-                            "target": 50,
-                            "window": "5m",
-                            "description": "Emergency response time (ms)",
-                        },
-                    },
-                },
-            ],
-        }
-
-    def _create_energy_advanced(self) -> dict[str, Any]:
-        """Create advanced energy template"""
-        basic = self._create_energy_basic()
-        basic["system"]["name"] = "Advanced Energy Grid ML System"
-        basic["collectors"].append(
-            {
-                "type": "regulatory",
-                "compliance_standards": ["IEC-61508", "ISO-13849"],
-            }
-        )
-        return basic
-
-    def _create_manufacturing_basic(self) -> dict[str, Any]:
-        """Create basic manufacturing template"""
-        return {
-            "system": {
-                "name": "Manufacturing ML System",
-                "type": "workflow",
-                "criticality": "business_critical",
-            },
-            "slos": {
-                "quality_control": {
-                    "target": 0.95,
-                    "window": "8h",
-                    "description": "Quality control accuracy",
-                    "safety_critical": False,
-                    "compliance_standard": "ISO-13485",
-                },
-                "throughput": {
-                    "target": 1000,
+                    "target": 0.99,
                     "window": "1h",
-                    "description": "Production throughput (units/hour)",
-                    "safety_critical": False,
+                    "description": "Proportion of system responses within 2 seconds",
                 },
             },
             "collectors": [
                 {
                     "type": "online",
-                    "endpoint": "http://manufacturing-metrics:9090",
-                },
-                {
-                    "type": "environmental",
-                    "sensor_types": ["temperature", "humidity", "vibration"],
+                    "endpoints": ["http://grid-monitor:8080/metrics"],
+                    "metrics": ["load_prediction", "response_time"],
                 },
             ],
             "evaluators": [
                 {
                     "type": "performance",
-                    "thresholds": {
-                        "quality_control": {"target": 0.95, "warning": 0.90},
-                        "throughput": {"target": 1000, "warning": 900},
-                    },
-                },
-                {
-                    "type": "reliability",
+                    "metrics": ["load_prediction_accuracy", "response_time"],
                 },
             ],
         }
 
-    def _create_manufacturing_advanced(self) -> dict[str, Any]:
-        """Create advanced manufacturing template"""
-        basic = self._create_manufacturing_basic()
-        basic["system"]["name"] = "Advanced Manufacturing ML System"
-        basic["collectors"].append(
-            {
-                "type": "regulatory",
-                "compliance_standards": ["ISO-13485", "FDA-510K"],
-            }
-        )
-        return basic
-
-    def _create_maritime_basic(self) -> dict[str, Any]:
-        """Create basic maritime template"""
+    def _create_energy_demand_prediction(self) -> dict[str, Any]:
+        """Create energy demand prediction template"""
         return {
             "system": {
-                "name": "Maritime ML System",
-                "type": "workflow",
-                "criticality": "safety_critical",
+                "name": "Energy Demand Prediction System",
+                "persona": "Grid Operator",
+                "criticality": "business_critical",
+                "description": "Energy demand prediction and grid optimization system",
             },
             "slos": {
-                "collision_avoidance": {
-                    "target": 0.99,
-                    "window": "1h",
-                    "description": "Collision avoidance accuracy",
-                    "safety_critical": True,
-                    "compliance_standard": "SOLAS",
-                },
-                "navigation_accuracy": {
-                    "target": 0.98,
+                "load_prediction_accuracy": {
+                    "target": 0.95,
                     "window": "24h",
-                    "description": "Navigation system accuracy",
-                    "safety_critical": True,
+                    "description": "Accuracy of energy demand prediction",
+                },
+                "system_availability": {
+                    "target": 0.999,
+                    "window": "30d",
+                    "description": "System uptime for grid optimization",
                 },
             },
             "collectors": [
                 {
                     "type": "online",
-                    "endpoint": "http://maritime-system:8080/metrics",
+                    "endpoints": ["http://grid-monitor:8080/metrics"],
+                    "metrics": ["load_prediction", "availability"],
+                },
+            ],
+            "evaluators": [
+                {
+                    "type": "performance",
+                    "metrics": ["load_prediction_accuracy"],
                 },
                 {
-                    "type": "environmental",
-                    "sensor_types": ["temperature", "humidity", "pressure"],
+                    "type": "reliability",
+                    "error_budget_window": "30d",
+                    "critical_metrics": ["system_availability"],
+                },
+            ],
+        }
+
+    def _create_manufacturing_predictive_maintenance(self) -> dict[str, Any]:
+        """Create manufacturing predictive maintenance template"""
+        return {
+            "system": {
+                "name": "Manufacturing Predictive Maintenance System",
+                "persona": "Maintenance Engineer",
+                "criticality": "business_critical",
+                "description": "ML system for manufacturing equipment monitoring",
+            },
+            "slos": {
+                "equipment_failure_prediction": {
+                    "target": 0.92,
+                    "window": "24h",
+                    "description": "Accuracy of equipment failure prediction",
+                },
+                "system_availability": {
+                    "target": 0.999,
+                    "window": "30d",
+                    "description": "System uptime for maintenance functionality",
+                },
+            },
+            "collectors": [
+                {
+                    "type": "online",
+                    "endpoints": ["http://equipment-monitor:8080/metrics"],
+                    "metrics": ["failure_prediction", "availability"],
+                },
+            ],
+            "evaluators": [
+                {
+                    "type": "performance",
+                    "metrics": ["equipment_failure_prediction"],
+                },
+                {
+                    "type": "reliability",
+                    "error_budget_window": "30d",
+                    "critical_metrics": ["system_availability"],
+                },
+            ],
+        }
+
+    def _create_manufacturing_demand_forecasting(self) -> dict[str, Any]:
+        """Create manufacturing demand forecasting template"""
+        return {
+            "system": {
+                "name": "Manufacturing Demand Forecasting System",
+                "persona": "Supply Chain Manager",
+                "criticality": "business_critical",
+                "description": "ML system for manufacturing demand forecasting",
+            },
+            "slos": {
+                "demand_forecast_accuracy": {
+                    "target": 0.90,
+                    "window": "30d",
+                    "description": "Accuracy of demand forecasting",
+                },
+                "forecast_response_time": {
+                    "target": 0.99,
+                    "window": "1h",
+                    "description": "Proportion of forecast requests completed within 5 minutes",
+                },
+            },
+            "collectors": [
+                {
+                    "type": "online",
+                    "endpoints": ["http://forecast-engine:8080/metrics"],
+                    "metrics": ["demand_prediction", "response_time"],
+                },
+            ],
+            "evaluators": [
+                {
+                    "type": "performance",
+                    "metrics": ["demand_forecast_accuracy", "forecast_response_time"],
+                },
+            ],
+        }
+
+    def _create_maritime_collision_avoidance(self) -> dict[str, Any]:
+        """Create maritime collision avoidance template"""
+        return {
+            "system": {
+                "name": "Maritime Collision Avoidance System",
+                "persona": "Ship Captain",
+                "criticality": "safety_critical",
+                "description": "Safety-critical collision avoidance system for maritime vessels",
+            },
+            "slos": {
+                "collision_detection_accuracy": {
+                    "target": 0.999,
+                    "window": "24h",
+                    "description": "Accuracy of collision detection and avoidance",
+                },
+                "response_time": {
+                    "target": 0.99,
+                    "window": "1h",
+                    "description": "Proportion of collision alerts within 2 seconds",
+                },
+            },
+            "collectors": [
+                {
+                    "type": "online",
+                    "endpoints": ["http://maritime-monitor:8080/metrics"],
+                    "metrics": ["collision_detection", "response_time"],
                 },
             ],
             "evaluators": [
                 {
                     "type": "safety",
-                    "compliance_standards": ["SOLAS", "MARPOL"],
-                },
-                {
-                    "type": "reliability",
-                    "error_budget_window": "30d",
-                    "slos": {
-                        "collision_avoidance": {
-                            "target": 0.99,
-                            "window": "1h",
-                            "description": "Collision avoidance accuracy",
-                        },
-                        "navigation_accuracy": {
-                            "target": 0.98,
-                            "window": "24h",
-                            "description": "Navigation system accuracy",
-                        },
-                    },
+                    "compliance_standards": ["SOLAS", "COLREGS"],
+                    "critical_metrics": ["collision_detection_accuracy"],
                 },
             ],
         }
 
-    def _create_maritime_advanced(self) -> dict[str, Any]:
-        """Create advanced maritime template"""
-        basic = self._create_maritime_basic()
-        basic["system"]["name"] = "Advanced Maritime ML System"
-        basic["collectors"].append(
-            {
-                "type": "regulatory",
-                "compliance_standards": ["SOLAS", "MARPOL"],
-            }
-        )
-        return basic
+    def _create_maritime_navigation_system(self) -> dict[str, Any]:
+        """Create maritime navigation system template"""
+        return {
+            "system": {
+                "name": "Maritime Navigation System",
+                "persona": "Ship Captain",
+                "criticality": "safety_critical",
+                "description": "Maritime navigation and safety system",
+            },
+            "slos": {
+                "collision_detection_accuracy": {
+                    "target": 0.999,
+                    "window": "24h",
+                    "description": "Accuracy of collision detection and avoidance",
+                },
+                "system_availability": {
+                    "target": 0.9999,
+                    "window": "30d",
+                    "description": "System uptime for navigation functionality",
+                },
+            },
+            "collectors": [
+                {
+                    "type": "online",
+                    "endpoints": ["http://maritime-monitor:8080/metrics"],
+                    "metrics": ["collision_detection", "availability"],
+                },
+            ],
+            "evaluators": [
+                {
+                    "type": "safety",
+                    "compliance_standards": ["SOLAS", "COLREGS"],
+                    "critical_metrics": ["collision_detection_accuracy"],
+                },
+                {
+                    "type": "reliability",
+                    "error_budget_window": "30d",
+                    "critical_metrics": ["system_availability"],
+                },
+            ],
+        }
+

--- a/ml_eval/templates/factory.py
+++ b/ml_eval/templates/factory.py
@@ -117,7 +117,11 @@ class TemplateFactory:
                 {
                     "type": "online",
                     "endpoints": ["http://flight-systems:8080/metrics"],
-                    "metrics": ["flight_path_accuracy", "response_time", "availability"],
+                    "metrics": [
+                        "flight_path_accuracy",
+                        "response_time",
+                        "availability",
+                    ],
                 },
             ],
             "evaluators": [
@@ -366,4 +370,3 @@ class TemplateFactory:
                 },
             ],
         }
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,21 +99,21 @@ def manufacturing_config():
     """Configuration for manufacturing industry testing"""
     return {
         "system": {
-            "name": "quality_control_system",
+            "name": "predictive_maintenance_system",
             "type": "workflow",
             "criticality": "business_critical",
         },
         "slos": {
-            "defect_detection": {
-                "target": 0.98,
+            "equipment_failure_prediction": {
+                "target": 0.92,
                 "window": "24h",
-                "description": "Quality control defect detection",
+                "description": "Equipment failure prediction accuracy",
                 "business_impact": "millions_per_hour",
             },
-            "prediction_latency": {
-                "target": 0.99,
-                "window": "1h",
-                "description": "Real-time prediction latency",
+            "maintenance_cost_reduction": {
+                "target": 0.15,
+                "window": "30d",
+                "description": "Maintenance cost reduction",
             },
         },
     }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,7 +101,7 @@ class TestEndToEndEvaluation:
         result = framework.evaluate()
 
         # Verify manufacturing-specific aspects
-        assert result.system_name == "quality_control_system"
+        assert result.system_name == "predictive_maintenance_system"
         assert result.timestamp is not None
         assert isinstance(result.overall_compliance, float)
         assert isinstance(result.has_critical_violations, bool)
@@ -150,24 +150,24 @@ class TestEndToEndEvaluation:
 class TestIndustrySpecificScenarios:
     """Test industry-specific evaluation scenarios"""
 
-    def test_manufacturing_quality_control_scenario(self):
-        """Test manufacturing quality control scenario"""
+    def test_manufacturing_predictive_maintenance_scenario(self):
+        """Test manufacturing predictive maintenance scenario"""
         config = {
             "system": {
-                "name": "quality_control_system",
+                "name": "predictive_maintenance_system",
                 "type": "workflow",
                 "criticality": "business_critical",
             },
             "slos": {
-                "quality_control": {
-                    "target": 0.98,
+                "equipment_failure_prediction": {
+                    "target": 0.92,
                     "window": "24h",
-                    "description": "Quality control accuracy",
+                    "description": "Equipment failure prediction accuracy",
                 },
-                "production_efficiency": {
-                    "target": 0.99,
-                    "window": "8h",
-                    "description": "Production efficiency",
+                "maintenance_cost_reduction": {
+                    "target": 0.15,
+                    "window": "30d",
+                    "description": "Maintenance cost reduction",
                 },
             },
         }
@@ -185,7 +185,7 @@ class TestIndustrySpecificScenarios:
         result = framework.evaluate()
 
         # Verify manufacturing-specific results
-        assert result.system_name == "quality_control_system"
+        assert result.system_name == "predictive_maintenance_system"
         assert len(result.recommendations) >= 0
         assert result.timestamp is not None
         assert isinstance(result.overall_compliance, float)


### PR DESCRIPTION
### Changes Made:
- **Added 2 manufacturing examples**: `predictive-maintenance.yaml` and `product-demand-forecasting.yaml` to provide industry-specific use cases
- **Updated get-started guide**: Now uses predictive maintenance as the primary example for easier onboarding
- **Simplified template factory**: Reduced all templates to minimum viable configurations by removing excessive complexity:
  - Streamlined SLOs from 6-8 to 2-3 essential metrics per template
  - Simplified collectors to single online collector per template
  - Reduced evaluators to 1-2 core types per template
  - Removed complex configurations (operating conditions, safety thresholds, multiple report types)

### Benefits:
- More approachable templates that users can build upon
- Clear manufacturing examples for industry-specific guidance
- Improved developer experience with simpler starting configurations